### PR TITLE
fix: Sampling was not working since refactor of duplicated code

### DIFF
--- a/render_tnocs_tensor.py
+++ b/render_tnocs_tensor.py
@@ -7,7 +7,7 @@ from PIL import Image
 from plyfile import PlyData, PlyElement
 from scipy.spatial.transform import Rotation as R
 
-from utils import estimate_center_scale, standardize_pc, colormap
+from utils import estimate_center_scale, standardize_pc, sample_pcl, colormap
 
 PATH_TO_MITSUBA2 = "/home/tolga/Codes/mitsuba2/build/dist/mitsuba"  # mitsuba exectuable
 
@@ -89,7 +89,7 @@ def estimate_bbox_all(pcls, points_per_object):
     center = [0,0,0]
     scale = 0
     for i in range(0,pclsSize[0]):
-        [centerCur, scaleCur] = estimate_center_scale(pcls[i,:,:], points_per_object)
+        [centerCur, scaleCur] = estimate_center_scale(sample_pcl(pcls[i,:,:], points_per_object))
         center = center + centerCur
         scale = scale + scaleCur
     center = center / pclsSize[0]

--- a/utils.py
+++ b/utils.py
@@ -11,10 +11,13 @@ def colormap(x, y, z):
     return [vec[0], vec[1], vec[2]]
 
 
-def estimate_center_scale(pcl, points_per_object):
+def sample_pcl(pcl, points_per_object):
     pt_indices = np.random.choice(pcl.shape[0], points_per_object, replace=False)
     np.random.shuffle(pt_indices)
-    pcl = pcl[pt_indices]  # n by 3
+    return pcl[pt_indices]
+
+
+def estimate_center_scale(pcl):
     mins = np.amin(pcl, axis=0)
     maxs = np.amax(pcl, axis=0)
     center = (mins + maxs) / 2.
@@ -29,7 +32,8 @@ def standardize_pc(pcl, center, scale):
 
 
 def standardize_bbox(pcl, points_per_object):
-    center, scale = estimate_center_scale(pcl, points_per_object)
+    pcl = sample_pcl(pcl, points_per_object)
+    center, scale = estimate_center_scale(pcl)
     return standardize_pc(pcl, center, scale)
 
 


### PR DESCRIPTION
When I did the refactor, I didn't realize the resampling part in the estimate_center_scale wasn't being stored after the refactor.

Here, I created another function, so I fix that behaviour.